### PR TITLE
A couple of updates to add support of Idx project.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 Running changelog of releases since `2.0.1`
 
+## v3.0.0
+
+- Add support for `json+ion` error responses.
+- Add support to configure Authorization Headers. 
+- Rename `CreatedScoped` to `CreateScoped`.
+- Add `SendAsync` method in `BaseOktaClient`.
+
 ## v2.0.1
 
 

--- a/src/Okta.Sdk.Abstractions.UnitTests/Internal/MockedStringRequestExecutor.cs
+++ b/src/Okta.Sdk.Abstractions.UnitTests/Internal/MockedStringRequestExecutor.cs
@@ -14,13 +14,14 @@ namespace Okta.Sdk.Abstractions.UnitTests.Internal
     {
         private readonly string _returnThis;
         private readonly int _statusCode;
-
+        private readonly IEnumerable<KeyValuePair<string, IEnumerable<string>>> _headers;
         public string OktaDomain => throw new NotImplementedException();
 
-        public MockedStringRequestExecutor(string returnThis, int statusCode = 200)
+        public MockedStringRequestExecutor(string returnThis, int statusCode = 200, IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers = null)
         {
             _returnThis = returnThis;
             _statusCode = statusCode;
+            _headers = headers;
         }
 
         public Task<HttpResponse<string>> GetAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, CancellationToken cancellationToken)
@@ -28,12 +29,16 @@ namespace Okta.Sdk.Abstractions.UnitTests.Internal
             {
                 StatusCode = _statusCode,
                 Payload = _returnThis,
+                Headers = _headers,
             });
 
         public Task<HttpResponse<string>> PostAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken)
+        => Task.FromResult(new HttpResponse<string>
         {
-            throw new NotImplementedException();
-        }
+            StatusCode = _statusCode,
+            Payload = _returnThis,
+            Headers = _headers,
+        });
 
         public Task<HttpResponse<string>> PutAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken)
         {

--- a/src/Okta.Sdk.Abstractions.UnitTests/Internal/TestableOktaClient.cs
+++ b/src/Okta.Sdk.Abstractions.UnitTests/Internal/TestableOktaClient.cs
@@ -19,7 +19,7 @@ namespace Okta.Sdk.Abstractions.UnitTests.Internal
 
         public TestableOktaClient(IRequestExecutor requestExecutor)
             : base(
-                new DefaultDataStore(requestExecutor, new DefaultSerializer(), new ResourceFactory(null, null, null), NullLogger.Instance, new UserAgentBuilder("test", typeof(BaseOktaClient).GetTypeInfo().Assembly.GetName().Version)),
+                new DefaultDataStore(requestExecutor, new DefaultSerializer(), new ResourceFactory(null, null, null), NullLogger.Instance, new UserAgentBuilder("test", typeof(IOktaClient).GetTypeInfo().Assembly.GetName().Version)),
                 DefaultFakeConfiguration,
                 new RequestContext())
         {

--- a/src/Okta.Sdk.Abstractions.UnitTests/UrlHelperShould.cs
+++ b/src/Okta.Sdk.Abstractions.UnitTests/UrlHelperShould.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace Okta.Sdk.Abstractions.UnitTests
+{
+    public class UrlHelperShould
+    {
+        [Theory]
+        [InlineData("https://devex-testing.oktapreview.com/oauth2/default", "https://devex-testing.oktapreview.com")]
+        [InlineData("https://devex-testing.okta.com/oauth2/default", "https://devex-testing.okta.com")]
+        [InlineData("http://devex-testing.okta.com/oauth2/default", "http://devex-testing.okta.com")]
+        public void GetOktaDomain(string issuer, string expectedOktaDomain)
+        {
+            UrlHelper.GetOktaDomain(issuer).Should().Be(expectedOktaDomain);
+        }
+    }
+}

--- a/src/Okta.Sdk.Abstractions.UnitTests/UrlHelperShould.cs
+++ b/src/Okta.Sdk.Abstractions.UnitTests/UrlHelperShould.cs
@@ -12,7 +12,7 @@ namespace Okta.Sdk.Abstractions.UnitTests
         [InlineData("http://devex-testing.okta.com/oauth2/default", "http://devex-testing.okta.com")]
         public void GetOktaDomain(string issuer, string expectedOktaDomain)
         {
-            UrlHelper.GetOktaDomain(issuer).Should().Be(expectedOktaDomain);
+            UrlHelper.GetOktaRootUrl(issuer).Should().Be(expectedOktaDomain);
         }
     }
 }

--- a/src/Okta.Sdk.Abstractions/AuthorizationSettings.cs
+++ b/src/Okta.Sdk.Abstractions/AuthorizationSettings.cs
@@ -8,6 +8,9 @@ using System.Text;
 
 namespace Okta.Sdk.Abstractions
 {
+    /// <summary>
+    /// A class to configure the Authorization settings for a request.
+    /// </summary>
     public class AuthorizationSettings
     {
         /// <summary>

--- a/src/Okta.Sdk.Abstractions/AuthorizationSettings.cs
+++ b/src/Okta.Sdk.Abstractions/AuthorizationSettings.cs
@@ -1,0 +1,43 @@
+﻿// <copyright file="AuthorizationSettings.cs" company="Okta, Inc">
+// Copyright (c) 2018 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Text;
+
+namespace Okta.Sdk.Abstractions
+{
+    public class AuthorizationSettings
+    {
+        /// <summary>
+        /// Gets or sets the Authorization header scheme.
+        /// </summary>
+        public AuthorizationType AuthorizationType { get; set; } = AuthorizationType.None;
+
+        /// <summary>
+        /// Gets or sets the Authorization header value.
+        /// </summary>
+        public string Value { get; set; }
+
+        /// <summary>
+        /// Gets the default Authorization Settings.
+        /// </summary>
+        /// <returns>The default Authorization Settings.</returns>
+        public static AuthorizationSettings GetDefault()
+                => new AuthorizationSettings { AuthorizationType = AuthorizationType.None };
+
+        /// <summary>
+        /// Returns the base64 encoded clientId:clientSecret.
+        /// </summary>
+        /// <param name="clientId">The client ID.</param>
+        /// <param name="clientSecret">The client Secret.</param>
+        /// <returns>The encoded client credentials.</returns>
+        public static string EncodeClientCredentials(string clientId, string clientSecret)
+        {
+            var clientCredentialsBytes = Encoding.ASCII.GetBytes($"{clientId}:{clientSecret}");
+
+            return Convert.ToBase64String(clientCredentialsBytes);
+        }
+    }
+}

--- a/src/Okta.Sdk.Abstractions/AuthorizationType.cs
+++ b/src/Okta.Sdk.Abstractions/AuthorizationType.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Okta.Sdk.Abstractions
+{
+    public enum AuthorizationType
+    {
+        None,
+        Basic,
+        Ssws,
+    }
+}

--- a/src/Okta.Sdk.Abstractions/AuthorizationType.cs
+++ b/src/Okta.Sdk.Abstractions/AuthorizationType.cs
@@ -1,13 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// <copyright file="AuthorizationType.cs" company="Okta, Inc">
+// Copyright (c) 2018 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
 
 namespace Okta.Sdk.Abstractions
 {
+    /// <summary>
+    /// The Authorization type.
+    /// </summary>
     public enum AuthorizationType
     {
+        /// <summary>
+        /// Authorization is not required.
+        /// </summary>
         None,
+
+        /// <summary>
+        /// Authorization is Basic.
+        /// </summary>
         Basic,
+
+        /// <summary>
+        /// Authorization is SSWS.
+        /// </summary>
         Ssws,
     }
 }

--- a/src/Okta.Sdk.Abstractions/BaseOktaClient.cs
+++ b/src/Okta.Sdk.Abstractions/BaseOktaClient.cs
@@ -224,7 +224,7 @@ namespace Okta.Sdk.Abstractions
             => _dataStore.DeleteAsync(request, _requestContext, cancellationToken);
 
         /// <inheritdoc/>
-        public async Task<TResponse> SendAsync<TResponse>(HttpRequest request, HttpVerb httpVerb, CancellationToken cancellationToken = default) 
+        public async Task<TResponse> SendAsync<TResponse>(HttpRequest request, HttpVerb httpVerb, CancellationToken cancellationToken = default)
             where TResponse : BaseResource, new()
         {
             switch (httpVerb)

--- a/src/Okta.Sdk.Abstractions/BaseOktaClient.cs
+++ b/src/Okta.Sdk.Abstractions/BaseOktaClient.cs
@@ -128,11 +128,13 @@ namespace Okta.Sdk.Abstractions
             return compiledConfig;
         }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Gets or sets the Okta configuration.
+        /// </summary>
         public OktaClientConfiguration Configuration { get; protected set; }
 
         /// <inheritdoc/>
-        public IOktaClient CreatedScoped(RequestContext requestContext)
+        public IOktaClient CreateScoped(RequestContext requestContext)
             => new BaseOktaClient(_dataStore, Configuration, requestContext);
 
         /// <summary>
@@ -220,5 +222,25 @@ namespace Okta.Sdk.Abstractions
         /// <inheritdoc/>
         public Task DeleteAsync(HttpRequest request, CancellationToken cancellationToken = default(CancellationToken))
             => _dataStore.DeleteAsync(request, _requestContext, cancellationToken);
+
+        /// <inheritdoc/>
+        public async Task<TResponse> SendAsync<TResponse>(HttpRequest request, HttpVerb httpVerb, CancellationToken cancellationToken = default) 
+            where TResponse : BaseResource, new()
+        {
+            switch (httpVerb)
+            {
+                case HttpVerb.Get:
+                    return await GetAsync<TResponse>(request, cancellationToken).ConfigureAwait(false);
+                case HttpVerb.Post:
+                    return await PostAsync<TResponse>(request, cancellationToken).ConfigureAwait(false);
+                case HttpVerb.Put:
+                    return await PutAsync<TResponse>(request, cancellationToken).ConfigureAwait(false);
+                case HttpVerb.Delete:
+                    await DeleteAsync(request, cancellationToken).ConfigureAwait(false);
+                    return null;
+                default:
+                    return await GetAsync<TResponse>(request, cancellationToken).ConfigureAwait(false);
+            }
+        }
     }
 }

--- a/src/Okta.Sdk.Abstractions/BaseResource.cs
+++ b/src/Okta.Sdk.Abstractions/BaseResource.cs
@@ -5,10 +5,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json;
 
 namespace Okta.Sdk.Abstractions
 {
@@ -61,7 +63,7 @@ namespace Okta.Sdk.Abstractions
         /// <returns>The <see cref="IOktaClient">OktaClient</see> that created this resource.</returns>
         protected IOktaClient GetClient()
         {
-            return _client ?? throw new InvalidOperationException("Only resources retrieved or saved through a Client object cna call server-side methods.");
+            return _client ?? throw new InvalidOperationException("Only resources retrieved or saved through a Client object can call server-side methods.");
         }
 
         /// <inheritdoc/>
@@ -327,6 +329,12 @@ namespace Okta.Sdk.Abstractions
         {
             var nestedData = GetPropertyOrNull(key) as IDictionary<string, object>;
             return _resourceFactory.CreateFromExistingData<T>(nestedData);
+        }
+
+        /// <inheritdoc/>
+        public string GetRaw()
+        {
+            return JsonConvert.SerializeObject(GetData(), Formatting.Indented);
         }
     }
 }

--- a/src/Okta.Sdk.Abstractions/DefaultDataStore.cs
+++ b/src/Okta.Sdk.Abstractions/DefaultDataStore.cs
@@ -131,6 +131,12 @@ namespace Okta.Sdk.Abstractions
             {
                 request.Headers["X-Forwarded-Proto"] = context.XForwardedProto;
             }
+
+            if (context.AuthorizationSettings.AuthorizationType != AuthorizationType.None)
+            {
+                request.Headers["Authorization-Scheme"] = context.AuthorizationSettings.AuthorizationType.ToString();
+                request.Headers["Authorization-Value"] = context.AuthorizationSettings.Value;
+            }
         }
 
         private void EnsureResponseSuccess(HttpResponse<string> response)
@@ -160,7 +166,18 @@ namespace Okta.Sdk.Abstractions
                 throw new InvalidOperationException($"An error occurred deserializing the error body for response code {response.StatusCode}. See the inner exception for details.", ex);
             }
 
-            throw new OktaApiException(response.StatusCode, _resourceFactory.CreateNew<ApiError>(errorData));
+            var contentTypeHeader = response.Headers.FirstOrDefault(x => string.Equals(x.Key, "Content-Type", StringComparison.OrdinalIgnoreCase));
+
+            // If error format is ION
+            if (!contentTypeHeader.Equals(default(KeyValuePair<string, string>))
+                && contentTypeHeader.Value.FirstOrDefault().Contains("application/ion+json"))
+            {
+                throw new OktaIonApiException(response.StatusCode, _resourceFactory.CreateNew<IonApiError>(errorData));
+            }
+            else
+            {
+                throw new OktaApiException(response.StatusCode, _resourceFactory.CreateNew<ApiError>(errorData));
+            }
         }
 
         private void PrepareRequest(HttpRequest request, RequestContext context)

--- a/src/Okta.Sdk.Abstractions/DefaultDataStore.cs
+++ b/src/Okta.Sdk.Abstractions/DefaultDataStore.cs
@@ -132,7 +132,7 @@ namespace Okta.Sdk.Abstractions
                 request.Headers["X-Forwarded-Proto"] = context.XForwardedProto;
             }
 
-            if (context.AuthorizationSettings.AuthorizationType != AuthorizationType.None)
+            if (context?.AuthorizationSettings?.AuthorizationType != AuthorizationType.None)
             {
                 request.Headers["Authorization-Scheme"] = context.AuthorizationSettings.AuthorizationType.ToString();
                 request.Headers["Authorization-Value"] = context.AuthorizationSettings.Value;

--- a/src/Okta.Sdk.Abstractions/DefaultRequestExecutor.cs
+++ b/src/Okta.Sdk.Abstractions/DefaultRequestExecutor.cs
@@ -73,7 +73,7 @@ namespace Okta.Sdk.Abstractions
 
         private string GetContentType(IEnumerable<KeyValuePair<string, string>> headers)
         {
-            var contentType = HttpRequestContentBuilder.CONTENT_TYPE_JSON;
+            var contentType = HttpRequestContentBuilder.ContentTypeJson;
 
             if (headers != null)
             {
@@ -81,7 +81,7 @@ namespace Okta.Sdk.Abstractions
 
                 if (!header.Equals(default(KeyValuePair<string, string>)))
                 {
-                    contentType = string.IsNullOrEmpty(header.Value) ? HttpRequestContentBuilder.CONTENT_TYPE_JSON : header.Value;
+                    contentType = string.IsNullOrEmpty(header.Value) ? HttpRequestContentBuilder.ContentTypeJson : header.Value;
                 }
             }
 
@@ -127,6 +127,7 @@ namespace Okta.Sdk.Abstractions
                 {
                     request.Headers.Add(header.Key, header.Value);
                 }
+
                 // Authorization header is set with special via headers.Authorization.
                 if (string.Equals(header.Key, "Authorization-Scheme", StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/Okta.Sdk.Abstractions/DefaultRequestExecutor.cs
+++ b/src/Okta.Sdk.Abstractions/DefaultRequestExecutor.cs
@@ -7,7 +7,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -20,8 +22,6 @@ namespace Okta.Sdk.Abstractions
     /// </summary>
     public sealed class DefaultRequestExecutor : IRequestExecutor
     {
-        private const string OktaClientUserAgentName = "oktasdk-dotnet";
-
         private readonly string _oktaDomain;
         private readonly HttpClient _httpClient;
         private readonly ILogger _logger;
@@ -49,7 +49,6 @@ namespace Okta.Sdk.Abstractions
         private static void ApplyDefaultClientSettings(HttpClient client, string oktaDomain, OktaClientConfiguration configuration)
         {
             client.BaseAddress = new Uri(oktaDomain, UriKind.Absolute);
-            client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("SSWS", configuration.Token);
         }
 
         private string EnsureRelativeUrl(string uri)
@@ -70,6 +69,23 @@ namespace Okta.Sdk.Abstractions
             }
 
             return uri.TrimStart('/');
+        }
+
+        private string GetContentType(IEnumerable<KeyValuePair<string, string>> headers)
+        {
+            var contentType = HttpRequestContentBuilder.CONTENT_TYPE_JSON;
+
+            if (headers != null)
+            {
+                var header = headers.FirstOrDefault(x => string.Equals(x.Key, "Content-Type", StringComparison.OrdinalIgnoreCase));
+
+                if (!header.Equals(default(KeyValuePair<string, string>)))
+                {
+                    contentType = string.IsNullOrEmpty(header.Value) ? HttpRequestContentBuilder.CONTENT_TYPE_JSON : header.Value;
+                }
+            }
+
+            return contentType;
         }
 
         private async Task<HttpResponse<string>> SendAsync(
@@ -97,7 +113,7 @@ namespace Okta.Sdk.Abstractions
             }
         }
 
-        private static void ApplyHeadersToRequest(HttpRequestMessage request, IEnumerable<KeyValuePair<string, string>> headers)
+        private void ApplyHeadersToRequest(HttpRequestMessage request, IEnumerable<KeyValuePair<string, string>> headers)
         {
             if (headers == null || !headers.Any())
             {
@@ -106,7 +122,17 @@ namespace Okta.Sdk.Abstractions
 
             foreach (var header in headers)
             {
-                request.Headers.Add(header.Key, header.Value);
+                // Content-Type is set during the content creation. This is a limitation of .NET, that doesn't allow to set Content-Type as a request header.
+                if (!string.Equals(header.Key, "Content-Type", StringComparison.OrdinalIgnoreCase))
+                {
+                    request.Headers.Add(header.Key, header.Value);
+                }
+                // Authorization header is set with special via headers.Authorization.
+                if (string.Equals(header.Key, "Authorization-Scheme", StringComparison.OrdinalIgnoreCase))
+                {
+                    var authorizationHeaderValue = headers.FirstOrDefault(x => x.Key == "Authorization-Value").Value;
+                    _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(header.Value, authorizationHeaderValue);
+                }
             }
         }
 
@@ -128,13 +154,14 @@ namespace Okta.Sdk.Abstractions
         public Task<HttpResponse<string>> PostAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken)
         {
             var path = EnsureRelativeUrl(href);
+            var contentType = GetContentType(headers);
 
             var request = new HttpRequestMessage(HttpMethod.Post, new Uri(path, UriKind.Relative));
             ApplyHeadersToRequest(request, headers);
 
             request.Content = string.IsNullOrEmpty(body)
                 ? null
-                : new StringContent(body, System.Text.Encoding.UTF8, "application/json");
+                : HttpRequestContentBuilder.GetRequestContent(contentType, body);
 
             return SendAsync(request, cancellationToken);
         }
@@ -143,13 +170,14 @@ namespace Okta.Sdk.Abstractions
         public Task<HttpResponse<string>> PutAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken)
         {
             var path = EnsureRelativeUrl(href);
+            var contentType = GetContentType(headers);
 
             var request = new HttpRequestMessage(HttpMethod.Put, new Uri(path, UriKind.Relative));
             ApplyHeadersToRequest(request, headers);
 
             request.Content = string.IsNullOrEmpty(body)
                 ? null
-                : new StringContent(body, System.Text.Encoding.UTF8, "application/json");
+                : HttpRequestContentBuilder.GetRequestContent(contentType, body);
 
             return SendAsync(request, cancellationToken);
         }

--- a/src/Okta.Sdk.Abstractions/HttpRequestContentBuilder.cs
+++ b/src/Okta.Sdk.Abstractions/HttpRequestContentBuilder.cs
@@ -10,28 +10,38 @@ using Newtonsoft.Json;
 
 namespace Okta.Sdk.Abstractions
 {
+    /// <summary>
+    /// The request content builder.
+    /// </summary>
     public static class HttpRequestContentBuilder
     {
-        public const string CONTENT_TYPE_JSON = "application/json";
-        public const string CONTENT_TYPE_X_WWW_FORM_URL_ENCODED = "application/x-www-form-urlencoded";
-        // TODO: Add ION
+        /// <summary>
+        /// application/json
+        /// </summary>
+        public const string ContentTypeJson = "application/json";
+
+        /// <summary>
+        /// "application/x-www-form-urlencoded"
+        /// </summary>
+        public const string ContentTypeFormUrlEncoded = "application/x-www-form-urlencoded";
 
         /// <summary>
         /// Get an HttpContent.
         /// </summary>
+        /// <param name="contentType"> The request's content type.</param>
+        /// <param name="body"> The request's body.</param>
         /// <returns>The request's HttpContent.</returns>
-        public static HttpContent GetRequestContent(string contentType = CONTENT_TYPE_JSON, string body = null)
+        public static HttpContent GetRequestContent(string contentType = ContentTypeJson, string body = null)
         {
             switch (contentType)
             {
-                case CONTENT_TYPE_JSON:
+                case ContentTypeJson:
                     return string.IsNullOrEmpty(body) ? null : new StringContent(body, Encoding.UTF8, contentType);
-                case CONTENT_TYPE_X_WWW_FORM_URL_ENCODED:
+                case ContentTypeFormUrlEncoded:
                     return string.IsNullOrEmpty(body) ? null : new FormUrlEncodedContent(JsonConvert.DeserializeObject<Dictionary<string, string>>(body));
                 default:
                     return string.IsNullOrEmpty(body) ? null : new StringContent(body, Encoding.UTF8, contentType);
             }
         }
-
     }
 }

--- a/src/Okta.Sdk.Abstractions/HttpRequestContentBuilder.cs
+++ b/src/Okta.Sdk.Abstractions/HttpRequestContentBuilder.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="HttpRequestContentBuilder.cs" company="Okta, Inc">
+// Copyright (c) 2018 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Okta.Sdk.Abstractions
+{
+    public static class HttpRequestContentBuilder
+    {
+        public const string CONTENT_TYPE_JSON = "application/json";
+        public const string CONTENT_TYPE_X_WWW_FORM_URL_ENCODED = "application/x-www-form-urlencoded";
+        // TODO: Add ION
+
+        /// <summary>
+        /// Get an HttpContent.
+        /// </summary>
+        /// <returns>The request's HttpContent.</returns>
+        public static HttpContent GetRequestContent(string contentType = CONTENT_TYPE_JSON, string body = null)
+        {
+            switch (contentType)
+            {
+                case CONTENT_TYPE_JSON:
+                    return string.IsNullOrEmpty(body) ? null : new StringContent(body, Encoding.UTF8, contentType);
+                case CONTENT_TYPE_X_WWW_FORM_URL_ENCODED:
+                    return string.IsNullOrEmpty(body) ? null : new FormUrlEncodedContent(JsonConvert.DeserializeObject<Dictionary<string, string>>(body));
+                default:
+                    return string.IsNullOrEmpty(body) ? null : new StringContent(body, Encoding.UTF8, contentType);
+            }
+        }
+
+    }
+}

--- a/src/Okta.Sdk.Abstractions/HttpVerb.cs
+++ b/src/Okta.Sdk.Abstractions/HttpVerb.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿// <copyright file="HttpVerb.cs" company="Okta, Inc">
+// Copyright (c) 2018 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/Okta.Sdk.Abstractions/HttpVerb.cs
+++ b/src/Okta.Sdk.Abstractions/HttpVerb.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Okta.Sdk.Abstractions
+{
+    /// <summary>
+    /// HttpVerb enum.
+    /// </summary>
+    public enum HttpVerb
+    {
+        /// <summary>
+        /// Represents the GET method of the HTTP protocol.
+        /// </summary>
+        Get,
+
+        /// <summary>
+        /// Represents the POST method of the HTTP protocol.
+        /// </summary>
+        Post,
+
+        /// <summary>
+        /// Represents the PUT method of the HTTP protocol.
+        /// </summary>
+        Put,
+
+        /// <summary>
+        /// Represents the DELETE method of the HTTP protocol.
+        /// </summary>
+        Delete,
+    }
+}

--- a/src/Okta.Sdk.Abstractions/IIonApiError.cs
+++ b/src/Okta.Sdk.Abstractions/IIonApiError.cs
@@ -1,5 +1,13 @@
-﻿namespace Okta.Sdk.Abstractions
+﻿// <copyright file="IIonApiError.cs" company="Okta, Inc">
+// Copyright (c) 2018 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Okta.Sdk.Abstractions
 {
+    /// <summary>
+    /// Represents an json+ion formatted error returned by the Okta API.
+    /// </summary>
     public interface IIonApiError
     {
         /// <summary>

--- a/src/Okta.Sdk.Abstractions/IIonApiError.cs
+++ b/src/Okta.Sdk.Abstractions/IIonApiError.cs
@@ -1,0 +1,17 @@
+﻿namespace Okta.Sdk.Abstractions
+{
+    public interface IIonApiError
+    {
+        /// <summary>
+        /// Gets the <c>version</c> property.
+        /// </summary>
+        /// <value>The version.</value>
+        string Version { get; }
+
+        /// <summary>
+        /// Gets the <c>errorSummary</c> property.
+        /// </summary>
+        /// <value>The error summary.</value>
+        string ErrorSummary { get; }
+    }
+}

--- a/src/Okta.Sdk.Abstractions/IOktaClient.cs
+++ b/src/Okta.Sdk.Abstractions/IOktaClient.cs
@@ -15,14 +15,14 @@ namespace Okta.Sdk.Abstractions
     public interface IOktaClient
     {
         // TODO: Review this change. We could make this generic.
-        /// <summary>
-        /// Gets the configuration passed to this <see cref="IOktaClient">OktaClient</see>.
-        /// </summary>
-        /// <value>
-        /// The client configuration.
-        /// </value>
-        /// <remarks>The configuration is immutable after the client is initialized. This property references a copy of the configuration.</remarks>
-        //OktaClientConfiguration Configuration { get; }
+        ///// <summary>
+        ///// Gets the configuration passed to this <see cref="IOktaClient">OktaClient</see>.
+        ///// </summary>
+        ///// <value>
+        ///// The client configuration.
+        ///// </value>
+        ///// <remarks>The configuration is immutable after the client is initialized. This property references a copy of the configuration.</remarks>
+        // OktaClientConfiguration Configuration { get; }
 
         /// <summary>
         /// Creates a new <see cref="IOktaClient">OktaClient</see> scoped to the given request context.

--- a/src/Okta.Sdk.Abstractions/IOktaClient.cs
+++ b/src/Okta.Sdk.Abstractions/IOktaClient.cs
@@ -14,6 +14,7 @@ namespace Okta.Sdk.Abstractions
     /// </summary>
     public interface IOktaClient
     {
+        // TODO: Review this change. We could make this generic.
         /// <summary>
         /// Gets the configuration passed to this <see cref="IOktaClient">OktaClient</see>.
         /// </summary>
@@ -21,7 +22,7 @@ namespace Okta.Sdk.Abstractions
         /// The client configuration.
         /// </value>
         /// <remarks>The configuration is immutable after the client is initialized. This property references a copy of the configuration.</remarks>
-        OktaClientConfiguration Configuration { get; }
+        //OktaClientConfiguration Configuration { get; }
 
         /// <summary>
         /// Creates a new <see cref="IOktaClient">OktaClient</see> scoped to the given request context.
@@ -29,7 +30,7 @@ namespace Okta.Sdk.Abstractions
         /// <param name="requestContext">The request context</param>
         /// <remarks>This method is used to temporarily create a copy of the client in order to pass information about the current request to the Okta API.</remarks>
         /// <returns>The new client.</returns>
-        IOktaClient CreatedScoped(RequestContext requestContext);
+        IOktaClient CreateScoped(RequestContext requestContext);
 
         /// <summary>
         /// Gets a resource by URL and deserializes it to a <see cref="BaseResource"/> type.
@@ -208,5 +209,21 @@ namespace Okta.Sdk.Abstractions
         Task DeleteAsync(
             HttpRequest request,
             CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Sends data to an endpoint by specifying the HTTP request options, and deserializes the response payload to a <see cref="BaseResource"/> type.
+        /// </summary>
+        /// <remarks>You typically only need to use this method if you are working with resources not natively handled by this library.</remarks>
+        /// <typeparam name="TResponse">The <see cref="BaseResource"/> type to deserialize the returned data to.</typeparam>
+        /// <param name="request">The request options.</param>
+        /// /// <param name="httpVerb">The HTTP protocol verb.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The deserialized response data.</returns>
+        /// <exception cref="OktaApiException">An API error occurred.</exception>
+        Task<TResponse> SendAsync<TResponse>(
+            HttpRequest request,
+            HttpVerb httpVerb,
+            CancellationToken cancellationToken = default(CancellationToken))
+            where TResponse : BaseResource, new();
     }
 }

--- a/src/Okta.Sdk.Abstractions/IResource.cs
+++ b/src/Okta.Sdk.Abstractions/IResource.cs
@@ -34,6 +34,12 @@ namespace Okta.Sdk.Abstractions
         IDictionary<string, object> GetData();
 
         /// <summary>
+        /// Gets the raw JSON data backing this resource.
+        /// </summary>
+        /// <returns>The raw JSON data backing this resource</returns>
+        string GetRaw();
+
+        /// <summary>
         /// Sets a resource property by name
         /// </summary>
         /// <param name="name"> The property name</param>

--- a/src/Okta.Sdk.Abstractions/IonApiError.cs
+++ b/src/Okta.Sdk.Abstractions/IonApiError.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Okta.Sdk.Abstractions
+{
+    /// <inheritdoc/>
+    public sealed class IonApiError : BaseResource, IIonApiError
+    {
+        /// <inheritdoc/>
+        public string Version => GetStringProperty("version");
+
+        /// <inheritdoc/>
+        public string ErrorSummary => GetErrorSummary();
+
+        private string GetErrorSummary()
+        {
+            var sbErrorSumary = new StringBuilder();
+            var messageObj = this.GetProperty<BaseResource>("messages");
+
+            if (messageObj != null)
+            {
+                var messages = messageObj.GetArrayProperty<BaseResource>("value");
+
+                if (messages != null)
+                {
+                    foreach (var message in messages)
+                    {
+                        sbErrorSumary.AppendLine(message.GetProperty<string>("message"));
+                    }
+                }
+            }
+
+            return sbErrorSumary.ToString();
+        }
+    }
+}

--- a/src/Okta.Sdk.Abstractions/IonApiError.cs
+++ b/src/Okta.Sdk.Abstractions/IonApiError.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿// <copyright file="IonApiError.cs" company="Okta, Inc">
+// Copyright (c) 2018 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/Okta.Sdk.Abstractions/Okta.Sdk.Abstractions.csproj
+++ b/src/Okta.Sdk.Abstractions/Okta.Sdk.Abstractions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Version>2.0.1</Version>
+    <Version>3.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Okta.Sdk.Abstractions/OktaClientConfigurationValidator.cs
+++ b/src/Okta.Sdk.Abstractions/OktaClientConfigurationValidator.cs
@@ -25,7 +25,7 @@ namespace Okta.Sdk.Abstractions
                 throw new ArgumentNullException(nameof(configuration.OktaDomain), "Your Okta URL is missing. You can copy your domain from the Okta Developer Console. Follow these instructions to find it: https://bit.ly/finding-okta-domain");
             }
 
-            configuration.OktaDomain = EnsureTrailingSlash(configuration.OktaDomain);
+            configuration.OktaDomain = UrlHelper.EnsureTrailingSlash(configuration.OktaDomain);
 
             if (!configuration.DisableHttpsCheck && !configuration.OktaDomain.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
             {
@@ -53,21 +53,6 @@ namespace Okta.Sdk.Abstractions
             {
                 throw new ArgumentNullException(nameof(configuration.OktaDomain), $"It looks like there's a typo in your Okta domain. Current value: {configuration.OktaDomain}. You can copy your domain from the Okta Developer Console. Follow these instructions to find it: https://bit.ly/finding-okta-domain");
             }
-        }
-
-        /// <summary>
-        /// Ensures that this URI ends with a trailing slash <c>/</c>
-        /// </summary>
-        /// <param name="oktaDomain">The okta domain URI string</param>
-        /// <returns>The URI string, appended with <c>/</c> if necessary.</returns>
-        public static string EnsureTrailingSlash(string oktaDomain)
-        {
-            if (!oktaDomain.EndsWith("/"))
-            {
-                oktaDomain += "/";
-            }
-
-            return oktaDomain;
         }
     }
 }

--- a/src/Okta.Sdk.Abstractions/OktaIonApiException.cs
+++ b/src/Okta.Sdk.Abstractions/OktaIonApiException.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Okta.Sdk.Abstractions
+{
+    public class OktaIonApiException : OktaException
+    {
+        private readonly IonApiError _error;
+        public OktaIonApiException(int statusCode, IonApiError error)
+            : base(message: $"({statusCode}):({error.ErrorSummary})")
+        {
+            _error = error;
+            StatusCode = statusCode;
+        }
+
+        /// <summary>
+        /// Gets the HTTP status code.
+        /// </summary>
+        /// <value>
+        /// The HTTP status code.
+        /// </value>
+        public int StatusCode { get; }
+
+        /// <summary>
+        /// Gets the error object returned by the Okta API.
+        /// </summary>
+        /// <value>
+        /// The error object returned by the Okta API.
+        /// </value>
+        public IonApiError Error => _error;
+    }
+}

--- a/src/Okta.Sdk.Abstractions/OktaIonApiException.cs
+++ b/src/Okta.Sdk.Abstractions/OktaIonApiException.cs
@@ -1,12 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// <copyright file="OktaIonApiException.cs" company="Okta, Inc">
+// Copyright (c) 2018 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
 
 namespace Okta.Sdk.Abstractions
 {
+    /// <summary>
+    /// An exception wrapping a json+ion formatted error returned by the Okta API.
+    /// </summary>
     public class OktaIonApiException : OktaException
     {
         private readonly IonApiError _error;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OktaIonApiException"/> class.
+        /// </summary>
+        /// <param name="statusCode">The HTTP status code.</param>
+        /// <param name="error">The error data.</param>
         public OktaIonApiException(int statusCode, IonApiError error)
             : base(message: $"({statusCode}):({error.ErrorSummary})")
         {

--- a/src/Okta.Sdk.Abstractions/RequestContext.cs
+++ b/src/Okta.Sdk.Abstractions/RequestContext.cs
@@ -3,6 +3,8 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using Okta.Sdk.Abstractions.Configuration;
+
 namespace Okta.Sdk.Abstractions
 {
     /// <summary>
@@ -45,5 +47,10 @@ namespace Okta.Sdk.Abstractions
         /// The X-Forwarded-Port value.
         /// </value>
         public string XForwardedPort { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Authorization settings for the request. Default is None.
+        /// </summary>
+        public AuthorizationSettings AuthorizationSettings { get; set; } = AuthorizationSettings.GetDefault();
     }
 }

--- a/src/Okta.Sdk.Abstractions/UrlFormatter.cs
+++ b/src/Okta.Sdk.Abstractions/UrlFormatter.cs
@@ -3,6 +3,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -35,6 +36,27 @@ namespace Okta.Sdk.Abstractions
             // TODO sanitize dates as ISO 8601
 
             return WebUtility.UrlEncode(value.ToString());
+        }
+
+        /// <summary>
+        /// Encode values in Base 64 URL
+        /// </summary>
+        /// <param name="bytes">The bytes to encode.</param>
+        /// <returns>The encoded value.</returns>
+        public static string EncodeToBase64Url(byte[] bytes)
+        {
+
+            if (bytes == null)
+            {
+                return string.Empty;
+            }
+
+            char[] padding = { '=' };
+
+            return Convert.ToBase64String(bytes)
+                .TrimEnd(padding)
+                .Replace('+', '-')
+                .Replace('/', '_');
         }
 
         /// <summary>

--- a/src/Okta.Sdk.Abstractions/UrlHelper.cs
+++ b/src/Okta.Sdk.Abstractions/UrlHelper.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Okta.Sdk.Abstractions
+{
+    public static class UrlHelper
+    {
+        /// <summary>
+        /// Gets the Okta domain given an issuer.
+        /// </summary>
+        /// <param name="issuer">The issuer, for example, "https://test-org.oktapreview.com/oauth2/default".</param>
+        /// <returns>The Okta domain, for example, "https://test-org.oktapreview.com".</returns>
+        public static string GetOktaDomain(string issuer)
+        {
+            if (string.IsNullOrEmpty(issuer))
+            {
+                throw new ArgumentNullException(nameof(issuer));
+            }
+
+            Uri uri = new Uri(issuer);
+
+            return $"{uri.Scheme}://{uri.Host}";
+        }
+
+        /// <summary>
+        /// Ensures that this URI ends with a trailing slash <c>/</c>.
+        /// </summary>
+        /// <param name="uri">The URI string.</param>
+        /// <returns>The URI string, appended with <c>/</c> if necessary.</returns>
+        public static string EnsureTrailingSlash(string uri)
+        {
+            if (string.IsNullOrEmpty(uri))
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            return uri.EndsWith("/")
+                ? uri
+                : $"{uri}/";
+        }
+    }
+}

--- a/src/Okta.Sdk.Abstractions/UrlHelper.cs
+++ b/src/Okta.Sdk.Abstractions/UrlHelper.cs
@@ -1,9 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// <copyright file="UrlHelper.cs" company="Okta, Inc">
+// Copyright (c) 2018 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
 
 namespace Okta.Sdk.Abstractions
 {
+    /// <summary>
+    /// A utility class to manage URLs.
+    /// </summary>
     public static class UrlHelper
     {
         /// <summary>

--- a/src/Okta.Sdk.Abstractions/UrlHelper.cs
+++ b/src/Okta.Sdk.Abstractions/UrlHelper.cs
@@ -13,11 +13,11 @@ namespace Okta.Sdk.Abstractions
     public static class UrlHelper
     {
         /// <summary>
-        /// Gets the Okta domain given an issuer.
+        /// Gets the Okta root Url given an issuer.
         /// </summary>
         /// <param name="issuer">The issuer, for example, "https://test-org.oktapreview.com/oauth2/default".</param>
         /// <returns>The Okta domain, for example, "https://test-org.oktapreview.com".</returns>
-        public static string GetOktaDomain(string issuer)
+        public static string GetOktaRootUrl(string issuer)
         {
             if (string.IsNullOrEmpty(issuer))
             {

--- a/src/Okta.Sdk.Abstractions/UserAgentHelper.cs
+++ b/src/Okta.Sdk.Abstractions/UserAgentHelper.cs
@@ -21,7 +21,7 @@ namespace Okta.Sdk.Abstractions
         /// </summary>
         public static Version SdkVersion
         {
-            get { return typeof(BaseOktaClient).GetTypeInfo().Assembly.GetName().Version; }
+            get { return typeof(IOktaClient).GetTypeInfo().Assembly.GetName().Version; }
         }
 
         /// <summary>


### PR DESCRIPTION
* Add IonErrors and throw IonException when the response's content-type is `application/json+ion`
* Allow configuration for Authorization Headers. There are endpoints that may require an Authorization Header with client credentials.
* Add `SendAsync` method and allow passing the HttpVerb.
* Fix StyleCop warnings.
* Rename `CreatedScoped` to `CreateScoped`.