### PR TITLE
Improve errors and serialize null resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,38 @@
 # Changelog
 Running changelog of releases since `2.0.1`
 
+## v4.0.0
+
+### Updates
+
+- Moved `StatusCode` property to `OktaException` to be accessible by derived classes.
+- Refactor `OktaIonApiException` to show the message that come from the server instead of `(StatusCode):(Message)`.
+
+### Breaking changes
+
+- Change in default behavior when serializing resources (JSON objects). Previously, null resource properties would result in a resource object with all its properties set to `null`. Now, null resource properties would result in `null` property value. 
+
+_Before:_
+
+```
+{                                                 deserializedResource.Prop1.Should().Be("Hello World!");          
+    prop1 : "Hello World!",         =>            deserializedResource.NestedObject.Should().NotBeNull();
+    nestedObject: null                            deserializedResource.NestedObject.Prop1.Should().BeNull();
+}
+
+```
+
+_Now:_
+
+```
+{                                                 deserializedResource.Prop1.Should().Be("Hello World!");          
+    prop1 : "Hello World!",         =>            deserializedResource.NestedObject.Should().BeNull();
+    nestedObject: null                            
+}
+
+```
+
+
 ## v3.0.3
 - Add support for `json+ion` forms validation error responses 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@ Running changelog of releases since `2.0.1`
 
 ## v4.0.0
 
+### Features
+
+- Add `OktaOAuthException` to represent OAuth errors.
+
 ### Updates
 
 - Moved `StatusCode` property to `OktaException` to be accessible by derived classes.
-- Refactor `OktaIonApiException` to show the message that come from the server instead of `(StatusCode):(Message)`.
+- Refactor `OktaIonApiException` to show the message that comes from the server instead of `(StatusCode):(Message)`.
 
 ### Breaking changes
 

--- a/src/Okta.Sdk.Abstractions.UnitTests/NestedResourceShould.cs
+++ b/src/Okta.Sdk.Abstractions.UnitTests/NestedResourceShould.cs
@@ -16,7 +16,7 @@ namespace Okta.Sdk.Abstractions.UnitTests
         public void NotThrowForNonexistentNestedProperty()
         {
             var resource = new TestNestedResource();
-            resource.Nested.Should().NotBeNull();
+            resource.Nested.Should().BeNull();
         }
 
         [Fact]

--- a/src/Okta.Sdk.Abstractions/BaseResource.cs
+++ b/src/Okta.Sdk.Abstractions/BaseResource.cs
@@ -328,7 +328,15 @@ namespace Okta.Sdk.Abstractions
         private T GetResourcePropertyInternal<T>(string key)
         {
             var nestedData = GetPropertyOrNull(key) as IDictionary<string, object>;
-            return _resourceFactory.CreateFromExistingData<T>(nestedData);
+            var resourceProperty = _resourceFactory.CreateFromExistingData<T>(nestedData);
+
+            if (nestedData == null)
+            {
+                resourceProperty = default(T);
+                SetProperty(key, resourceProperty);
+            }
+
+            return resourceProperty;
         }
 
         /// <inheritdoc/>

--- a/src/Okta.Sdk.Abstractions/DefaultDataStore.cs
+++ b/src/Okta.Sdk.Abstractions/DefaultDataStore.cs
@@ -192,7 +192,7 @@ namespace Okta.Sdk.Abstractions
 
         // TODO: In the future refactor this to check OAuth endpoints instead
         private bool IsOAuthException(IDictionary<string, object> errorData) =>
-            errorData?.Keys.Contains("error_description") ?? false;
+            errorData?.Keys?.Contains("error_description") ?? false;
 
         private void PrepareRequest(HttpRequest request, RequestContext context)
         {

--- a/src/Okta.Sdk.Abstractions/DefaultDataStore.cs
+++ b/src/Okta.Sdk.Abstractions/DefaultDataStore.cs
@@ -179,11 +179,20 @@ namespace Okta.Sdk.Abstractions
             {
                 throw new OktaIonApiException(response.StatusCode, _resourceFactory.CreateNew<IonApiError>(errorData));
             }
+
+            if (IsOAuthException(errorData))
+            {
+                throw new OktaOAuthException(response.StatusCode, _resourceFactory.CreateNew<OAuthApiError>(errorData));
+            }
             else
             {
                 throw new OktaApiException(response.StatusCode, _resourceFactory.CreateNew<ApiError>(errorData));
             }
         }
+
+        // TODO: In the future refactor this to check OAuth endpoints instead
+        private bool IsOAuthException(IDictionary<string, object> errorData) =>
+            errorData?.Keys.Contains("error_description") ?? false;
 
         private void PrepareRequest(HttpRequest request, RequestContext context)
         {

--- a/src/Okta.Sdk.Abstractions/IOAuthApiError.cs
+++ b/src/Okta.Sdk.Abstractions/IOAuthApiError.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="IOAuthApiError.cs" company="Okta, Inc">
+// Copyright (c) 2018 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Okta.Sdk.Abstractions
+{
+    /// <summary>
+    /// Represents an error returned by the Okta OAuth API.
+    /// </summary>
+    public interface IOAuthApiError : IResource
+    {
+        /// <summary>
+        /// Gets the <c>error</c> property.
+        /// </summary>
+        /// <value>The error.</value>
+        string Error { get; }
+
+        /// <summary>
+        /// Gets the <c>error_description</c> property.
+        /// </summary>
+        /// <value>The error description.</value>
+        string ErrorDescription { get; }
+    }
+}

--- a/src/Okta.Sdk.Abstractions/OAuthApiError.cs
+++ b/src/Okta.Sdk.Abstractions/OAuthApiError.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="OAuthApiError.cs" company="Okta, Inc">
+// Copyright (c) 2018 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Okta.Sdk.Abstractions
+{
+    /// <inheritdoc/>
+    public class OAuthApiError : BaseResource, IOAuthApiError
+    {
+        /// <inheritdoc/>
+        public string Error => GetStringProperty("error");
+
+        /// <inheritdoc/>
+        public string ErrorDescription => GetStringProperty("error_description");
+    }
+
+    
+}

--- a/src/Okta.Sdk.Abstractions/Okta.Sdk.Abstractions.csproj
+++ b/src/Okta.Sdk.Abstractions/Okta.Sdk.Abstractions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Version>3.0.3</Version>
+    <Version>4.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Okta.Sdk.Abstractions/OktaApiException.cs
+++ b/src/Okta.Sdk.Abstractions/OktaApiException.cs
@@ -22,9 +22,8 @@ namespace Okta.Sdk.Abstractions
         /// <param name="statusCode">The HTTP status code.</param>
         /// <param name="error">The error data.</param>
         public OktaApiException(int statusCode, IApiError error)
-            : base(message: GetDetailedErrorMessage(statusCode, error))
+            : base(GetDetailedErrorMessage(statusCode, error), statusCode)
         {
-            StatusCode = statusCode;
             _error = error;
         }
 
@@ -35,14 +34,6 @@ namespace Okta.Sdk.Abstractions
         /// The error object returned by the Okta API.
         /// </value>
         public IApiError Error => _error;
-
-        /// <summary>
-        /// Gets the HTTP status code.
-        /// </summary>
-        /// <value>
-        /// The HTTP status code.
-        /// </value>
-        public int StatusCode { get; }
 
         /// <summary>
         /// Gets the error code from the <see cref="Error"/> object.

--- a/src/Okta.Sdk.Abstractions/OktaException.cs
+++ b/src/Okta.Sdk.Abstractions/OktaException.cs
@@ -22,6 +22,21 @@ namespace Okta.Sdk.Abstractions
         /// <summary>
         /// Initializes a new instance of the <see cref="OktaException"/> class.
         /// </summary>
+        /// <param name="message">
+        /// The message that describes the error.
+        /// </param>
+        /// <param name="statusCode">
+        /// The status Code.
+        /// </param>
+        public OktaException(string message, int statusCode)
+            : base(message)
+        {
+            StatusCode = statusCode;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OktaException"/> class.
+        /// </summary>
         /// <param name="message">The message that describes the error.</param>
         public OktaException(string message)
             : base(message)
@@ -37,5 +52,10 @@ namespace Okta.Sdk.Abstractions
             : base(message, innerException)
         {
         }
+
+        /// <summary>
+        /// Gets the HTTP status code.
+        /// </summary>
+        public int StatusCode { get; private set; }
     }
 }

--- a/src/Okta.Sdk.Abstractions/OktaIonApiException.cs
+++ b/src/Okta.Sdk.Abstractions/OktaIonApiException.cs
@@ -18,7 +18,7 @@ namespace Okta.Sdk.Abstractions
         /// <param name="statusCode">The HTTP status code.</param>
         /// <param name="error">The error data.</param>
         public OktaIonApiException(int statusCode, IonApiError error)
-            : base(message: $"({statusCode}):({error.ErrorSummary})")
+            : base(error.ErrorSummary, statusCode)
         {
             _error = error;
             StatusCode = statusCode;

--- a/src/Okta.Sdk.Abstractions/OktaOAuthException.cs
+++ b/src/Okta.Sdk.Abstractions/OktaOAuthException.cs
@@ -1,0 +1,54 @@
+﻿// <copyright file="OktaOAuthException.cs" company="Okta, Inc">
+// Copyright (c) 2018 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Okta.Sdk.Abstractions
+{
+    /// <summary>
+    /// An exception wrapping an error returned by the Okta OAuth API.
+    /// </summary>
+    public class OktaOAuthException : OktaException
+    {
+        private readonly IOAuthApiError _error;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OktaOAuthException"/> class.
+        /// </summary>
+        /// <param name="statusCode">The status code.</param>
+        /// <param name="error">the error.</param>
+        public OktaOAuthException(int statusCode, IOAuthApiError error)
+            : base(message: $"{error.Error} ({statusCode}, {error.ErrorDescription})")
+        {
+            StatusCode = statusCode;
+            _error = error;
+        }
+
+        /// <summary>
+        /// Gets the HTTP status code.
+        /// </summary>
+        /// <value>
+        /// The HTTP status code.
+        /// </value>
+        public int StatusCode { get; }
+
+        /// <summary>
+        /// Gets the error code from the <see cref="Error"/> object.
+        /// </summary>
+        /// <value>
+        /// The error.
+        /// </value>
+        public string Error => _error?.Error;
+
+        /// <summary>
+        /// Gets the error code from the <see cref="Error"/> object.
+        /// </summary>
+        /// <value>
+        /// The error description.
+        /// </value>
+        public string ErrorDescription => _error?.ErrorDescription;
+    }
+}


### PR DESCRIPTION
Version update from 3.0.3 to 4.0.0

### Updates

- Moved `StatusCode` property to `OktaException` to be accessible by derived classes.
- Refactor `OktaIonApiException` to show the message that comes from the server instead of `(StatusCode):(Message)`.

### Breaking changes

- Change in default behavior when serializing resources (JSON objects). Previously, null resource properties would result in a resource object with all its properties set to `null`. Now, null resource properties would result in `null` property value. 

_Before:_

```
{                                                 deserializedResource.Prop1.Should().Be("Hello World!");          
    prop1 : "Hello World!",         =>            deserializedResource.NestedObject.Should().NotBeNull();
    nestedObject: null                            deserializedResource.NestedObject.Prop1.Should().BeNull();
}

```

_Now:_

```
{                                                 deserializedResource.Prop1.Should().Be("Hello World!");          
    prop1 : "Hello World!",         =>            deserializedResource.NestedObject.Should().BeNull();
    nestedObject: null                            
}

```