### PR TITLE
OKTA-415867 .NET IDX SDK > Remove FlexibleConfiguration dependency an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Running changelog of releases since `2.0.1`
 
 ### Updates
 
-- Use Microsoft Configuration providers instead of [FlexibleConfiguration](https://github.com/nbarbettini/FlexibleConfiguration).
+- Remove [FlexibleConfiguration](https://github.com/nbarbettini/FlexibleConfiguration) dependency and use Microsoft Configuration providers instead.
 
 ## v4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 Running changelog of releases since `2.0.1`
 
+## v4.0.1
+
+### Updates
+
+- Use Microsoft Configuration providers instead of [FlexibleConfiguration](https://github.com/nbarbettini/FlexibleConfiguration).
+
 ## v4.0.0
 
 ### Features

--- a/src/Okta.Sdk.Abstractions.UnitTests/CustomConfigurationProvidersShould.cs
+++ b/src/Okta.Sdk.Abstractions.UnitTests/CustomConfigurationProvidersShould.cs
@@ -30,6 +30,15 @@ namespace Okta.Sdk.Abstractions.UnitTests
     requestTimeout: 0 # seconds
     rateLimit:
       maxRetries: 4
+fruits:
+  - Mango
+  - Orange
+  - Apple
+  - Pomegranate
+  - Watermelon
+  - Banana
+  - Papaya
+  - Guava
 ";
 
             byte[] bytes = Encoding.UTF8.GetBytes(yamlFile);
@@ -38,13 +47,21 @@ namespace Okta.Sdk.Abstractions.UnitTests
                 var yamlProvider = new TestableYamlConfigurationProvider(new YamlConfigurationSource());
                 yamlProvider.Load(stream);
 
-                yamlProvider.LoadedData.Should().HaveCount(6);
+                yamlProvider.LoadedData.Should().HaveCount(14);
                 yamlProvider.LoadedData.Should().Contain(new KeyValuePair<string, string>("okta:client:connectionTimeout", "99"));
                 yamlProvider.LoadedData.Should().Contain(new KeyValuePair<string, string>("okta:client:orgUrl", "https://OrgUrl.okta.com"));
                 yamlProvider.LoadedData.Should().Contain(new KeyValuePair<string, string>("okta:client:oktaDomain", "https://Domain.okta.com"));
                 yamlProvider.LoadedData.Should().Contain(new KeyValuePair<string, string>("okta:client:token", "tokentokentokentokentokentokentoken"));
                 yamlProvider.LoadedData.Should().Contain(new KeyValuePair<string, string>("okta:client:requestTimeout", "0"));
                 yamlProvider.LoadedData.Should().Contain(new KeyValuePair<string, string>("okta:client:rateLimit:maxRetries", "4"));
+                yamlProvider.LoadedData.Should().Contain(new KeyValuePair<string, string>("fruits:0", "Mango"));
+                yamlProvider.LoadedData.Should().Contain(new KeyValuePair<string, string>("fruits:1", "Orange"));
+                yamlProvider.LoadedData.Should().Contain(new KeyValuePair<string, string>("fruits:2", "Apple"));
+                yamlProvider.LoadedData.Should().Contain(new KeyValuePair<string, string>("fruits:3", "Pomegranate"));
+                yamlProvider.LoadedData.Should().Contain(new KeyValuePair<string, string>("fruits:4", "Watermelon"));
+                yamlProvider.LoadedData.Should().Contain(new KeyValuePair<string, string>("fruits:5", "Banana"));
+                yamlProvider.LoadedData.Should().Contain(new KeyValuePair<string, string>("fruits:6", "Papaya"));
+                yamlProvider.LoadedData.Should().Contain(new KeyValuePair<string, string>("fruits:7", "Guava"));
             }
         }
 

--- a/src/Okta.Sdk.Abstractions/Okta.Sdk.Abstractions.csproj
+++ b/src/Okta.Sdk.Abstractions/Okta.Sdk.Abstractions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Version>4.0.0</Version>
+    <Version>4.0.1</Version>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -35,6 +35,8 @@
   
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\OktaSdk.ruleset</CodeAnalysisRuleSet>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <FileVersion>4.0.1.0</FileVersion>
   </PropertyGroup>
   
 </Project>


### PR DESCRIPTION
…d use .NET Configuration Providers instead.

PR to change the version, changes were made in https://github.com/okta/okta-sdk-abstractions-dotnet/pull/14